### PR TITLE
Allow transformers 0.2

### DIFF
--- a/tagstream-conduit.cabal
+++ b/tagstream-conduit.cabal
@@ -36,7 +36,7 @@ Library
                      , bytestring
                      , text
                      , case-insensitive
-                     , transformers >= 0.3
+                     , transformers >= 0.2
                      , conduit >= 0.5 && < 1.1
                      , attoparsec
                      , blaze-builder


### PR DESCRIPTION
In particular, Travis CI seems to be failing with the transformers 0.3 requirement.
